### PR TITLE
Add JSON full (deep) merge type  Fixes #216

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/resources/MergeHelper.java
+++ b/src/main/java/de/igslandstuhl/database/server/resources/MergeHelper.java
@@ -34,6 +34,23 @@ public class MergeHelper {
             }
         );
     }
+    public static Map<String, ?> readJsonObjectFullMerged(ResourceManager manager, ResourceLocation location) {
+        Gson gson = new Gson();
+
+        return manager.mergeResources(location,
+                MergeHelper::deepMerge,
+                //start supplier
+                () -> (Map<String,Object>)new LinkedHashMap<String, Object>(),
+                // parser
+                (is) -> {
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+                        return gson.fromJson(reader, new TypeToken<Map<String, Object>>(){}.getType());
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+        );
+    }
     public static <T> List<T> readJsonListMerged(ResourceManager manager, ResourceLocation location, TypeToken<List<T>> listType) {
         Gson gson = new Gson();
 
@@ -78,5 +95,24 @@ public class MergeHelper {
                 }
             }
         );
+    }
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> deepMerge(Map<String, Object> a, Map<String, Object> b) {
+        for (Map.Entry<String, Object> entry : b.entrySet()) {
+            String key = entry.getKey();
+            Object newValue = entry.getValue();
+            Object oldValue = a.get(key);
+            if (oldValue instanceof Map && newValue instanceof Map) {
+                a.put(key, deepMerge((Map<String, Object>) oldValue, (Map<String, Object>) newValue));
+            }
+            else if (oldValue instanceof List && newValue instanceof List) {
+                ((List<Object>) oldValue).addAll((List<Object>) newValue);
+            }
+            else {
+                a.put(key, newValue);
+            }
+        }
+
+        return a;
     }
 }

--- a/src/main/java/de/igslandstuhl/database/server/resources/ResourceManager.java
+++ b/src/main/java/de/igslandstuhl/database/server/resources/ResourceManager.java
@@ -197,6 +197,9 @@ public class ResourceManager {
     public Map<String,?> readJsonResourceMerged(ResourceLocation location) {
         return MergeHelper.readJsonObjectMerged(this, location);
     }
+    public Map<String,?> readJsonResourceFullMerged(ResourceLocation location) {
+        return MergeHelper.readJsonObjectFullMerged(this, location);
+    }
     public <T> List<T> readJsonListMerged(ResourceLocation location, TypeToken<List<T>> token) {
         return MergeHelper.readJsonListMerged(this, location, token);
     }

--- a/src/test/java/de/igslandstuhl/database/server/resources/MergeHelperTest.java
+++ b/src/test/java/de/igslandstuhl/database/server/resources/MergeHelperTest.java
@@ -1,0 +1,51 @@
+package de.igslandstuhl.database.server.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+public class MergeHelperTest {
+
+    private static ResourceProvider provider(String json) {
+        return new ResourceProvider() {
+            @Override
+            public InputStream open(ResourceLocation location) {
+                return new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+            }
+            @Override
+            public Collection<ResourceLocation> list(Pattern pattern) {
+                return List.of();
+            }
+        };
+    }
+
+    @Test
+    public void fullMergeMergesNestedMapsAndLists() {
+        ResourceProvider base = provider(
+                "{ \"a\": \"old\", \"nested\": { \"x\": \"1\", \"y\": \"2\" }, \"list\": [\"a\", \"b\"] }");
+        ResourceProvider override = provider(
+                "{ \"a\": \"new\", \"nested\": { \"y\": \"20\", \"z\": \"30\" }, \"list\": [\"c\"] }");
+
+        ResourceManager manager = new ResourceManager(base, override);
+        Map<String, ?> result = manager.readJsonResourceFullMerged(
+                new ResourceLocation("test", "main", "config"));
+
+        assertEquals("new", result.get("a"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> nested = (Map<String, Object>) result.get("nested");
+        assertEquals("1", nested.get("x"));
+        assertEquals("20", nested.get("y"));
+        assertEquals("30", nested.get("z"));
+
+        assertEquals(List.of("a", "b", "c"), result.get("list"));
+    }
+}


### PR DESCRIPTION
 Fixes #216

Implements a recursive merge for JSON object resources (issue #216):
- lists are concatenated (JSON list merge)
- literals are overridden by the newer value
- maps are merged recursively

Adds MergeHelper.readJsonObjectFullMerged / deepMerge and the ResourceManager.readJsonResourceFullMerged wrapper, plus a unit test.