### PR TITLE
Restrict dependency submission to releases

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -57,6 +57,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   dependency-submission:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The dependency-submission job currently also runs for pull requests from forks. These runs cannot submit the dependency graph because the required repository permissions are unavailable.

This change restricts only the dependency-submission job to release events. The regular build and test job continues to run for pushes and pull requests.

Local verification:

- `./gradlew clean build --no-configuration-cache`
- Build and tests completed successfully

Fixes #218.