### PR TITLE
Fix redirect after adding a class

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
@@ -226,7 +226,7 @@ public class PostRequestHandler {
         });
         HttpHandler.registerPostRequestHandler("/add-class", AccessLevel.ADMIN, (rq) -> {
             SchoolClass.addClass(rq.getString("className"), rq.getInt("grade"));
-            return PostResponse.redirect("/manage_subjects", rq);
+            return PostResponse.redirect("/manage_classes", rq);
         });
         HttpHandler.registerPostRequestHandler("/lpt-file", AccessLevel.ADMIN, (rq) -> {
             String file = prepare(rq.getBodyAsString().replaceFirst("file=", "").replace("Â", ""));


### PR DESCRIPTION
After creating a class through `/add-class`, the handler redirected to `/manage_subjects`.

This changes the redirect target to `/manage_classes`, matching the page where classes are managed and the behavior of the existing class edit and delete handlers.

Local verification:

- `./gradlew clean build --no-configuration-cache`
- Build and tests completed successfully

Fixes #205.