### PR TITLE
Add release archive with regular JAR and resources

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Build fat JAR
       run: ./gradlew shadowJar --stacktrace --info
 
+    - name: Build ZIP with regular JAR and resources
+      run: ./gradlew releaseZip --stacktrace --info
+
     - name: Upload fat JAR as artifact
       uses: actions/upload-artifact@v4
       with:
@@ -52,7 +55,9 @@ jobs:
       if: github.event_name == 'release'
       uses: softprops/action-gh-release@v2
       with:
-        files: build/libs/student-database-*-fat.jar
+        files: |
+          build/libs/student-database-*-fat.jar
+          build/distributions/student-database-*-resources.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,3 +109,27 @@ publishing {
         }
     }
 }
+
+/**
+ * Creates a release archive containing the regular JAR and the resource
+ * directory used by FileResourceProvider.
+ */
+tasks.register<org.gradle.api.tasks.bundling.Zip>("releaseZip") {
+    group = "distribution"
+    description = "Bundles the regular JAR and external resource files."
+
+    val regularJar = tasks.named<org.gradle.api.tasks.bundling.Jar>("jar")
+
+    dependsOn(regularJar)
+
+    archiveBaseName.set("student-database")
+    archiveVersion.set(project.version.toString())
+    archiveClassifier.set("resources")
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+
+    from(regularJar.flatMap { it.archiveFile })
+
+    from("src/main/resources") {
+        into("resources")
+    }
+}


### PR DESCRIPTION
Adds a new `releaseZip` Gradle task that creates an additional distribution archive containing:

- the regular, non-fat JAR in the archive root
- the application resources under `resources/`

The Java CI workflow builds this archive and uploads it alongside the fat JAR when a GitHub release is published.

Local verification:

- `./gradlew clean build shadowJar releaseZip --no-configuration-cache`
- Build and tests completed successfully
- The generated ZIP contains one regular JAR and the expected external resource structure

Fixes #175.