### PR TITLE
Allow configuring the keystore type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Ensure you have the following installed:
      keytool -genkey -keyalg RSA -keystore keys/web/keystore.jks -storetype JKS
      ```
 
+     For a PKCS12 keystore, use for example:
+
+     ```bash
+     keytool -genkeypair -alias student-database -keyalg RSA -keystore keys/web/keystore.p12 -storetype PKCS12
+     ```
+
 ### ⬇️ Download latest release
 
 #### 🥖 Prerequisites
@@ -98,6 +104,9 @@ There are a few command line arguments you can give the program:
     Specifies the path to the keystore
 - `--keystore-password (keystore pass)`
     The password you entered when generating the keystore.
+- `--keystore-type (keystore type)`
+    Specifies the keystore type used by the web server, for example `JKS` or `PKCS12`.
+    Default value: `JKS`
 
 ### 🌐 Web interface
 

--- a/src/main/java/de/igslandstuhl/database/server/Server.java
+++ b/src/main/java/de/igslandstuhl/database/server/Server.java
@@ -93,8 +93,9 @@ public final class Server implements AutoCloseable {
             connection = new SQLiteConnection(Application.getInstance().getOptionSafe("database", Application.getInstance().beingTested() ? "test-server-" + System.currentTimeMillis() : "database"));
             String keystorePath = Application.getInstance().runsWebServer() ? Application.getInstance().getOptionSafe("keystore", "keys/web/keystore.jks") : null;
             String keystorePassword = Application.getInstance().runsWebServer() ? Application.getInstance().getOptionSafe("keystore-password", "changeit") : null;
+            String keystoreType = Application.getInstance().runsWebServer() ? Application.getInstance().getOptionSafe("keystore-type", "JKS") : null;
             int port = 443;
-            webServer = Application.getInstance().runsWebServer() ? new WebServer(port, keystorePath, keystorePassword) : new WebServer();
+            webServer = Application.getInstance().runsWebServer() ? new WebServer(port, keystorePath, keystorePassword, keystoreType) : new WebServer();
         } catch (Exception e) {
             throw new IllegalStateException("Server failed on start", e);
         }

--- a/src/main/java/de/igslandstuhl/database/server/WebServer.java
+++ b/src/main/java/de/igslandstuhl/database/server/WebServer.java
@@ -56,10 +56,10 @@ public class WebServer implements Runnable {
         return userManager;
     }
 
-    public WebServer(int port, String keystorePath, String keystorePassword)
+    public WebServer(int port, String keystorePath, String keystorePassword, String keystoreType)
             throws KeyStoreException, FileNotFoundException, IOException,
             NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException, KeyManagementException {
-        KeyStore ks = KeyStore.getInstance("JKS");
+        KeyStore ks = KeyStore.getInstance(keystoreType);
         try (FileInputStream fis = new FileInputStream(keystorePath)) {
             ks.load(fis, keystorePassword.toCharArray());
         }


### PR DESCRIPTION
## Summary

- add a `--keystore-type` application option
- keep `JKS` as the default for backwards compatibility
- pass the configured type to `KeyStore.getInstance`
- document JKS and PKCS12 usage in the README

## Verification

- `./gradlew clean build --no-configuration-cache`
- loaded generated JKS and PKCS12 keystores successfully with Java 17

Fixes #84
