### PR TITLE
Refactor cookie parsing into Cookie

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/webserver/Cookie.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/Cookie.java
@@ -28,6 +28,43 @@ public class Cookie {
     }
 
     /**
+     * Parses the value of a Cookie request header.
+     *
+     * <p>Cookie pairs are separated by semicolons. Each pair is split at
+     * the first equals sign so that equals signs inside cookie values are
+     * preserved. Invalid pairs and pairs without a name are ignored.</p>
+     *
+     * @param headerValue the value of the Cookie header
+     * @return the parsed cookies, or an empty array for a missing or empty
+     *         header value
+     */
+    public static Cookie[] parse(String headerValue) {
+        if (headerValue == null || headerValue.isBlank()) {
+            return new Cookie[0];
+        }
+
+        java.util.List<Cookie> cookies = new java.util.ArrayList<>();
+
+        for (String pair : headerValue.split(";")) {
+            String trimmedPair = pair.trim();
+            int separator = trimmedPair.indexOf('=');
+
+            if (separator < 0) {
+                continue;
+            }
+
+            String name = trimmedPair.substring(0, separator).trim();
+            String value = trimmedPair.substring(separator + 1).trim();
+
+            if (!name.isEmpty()) {
+                cookies.add(new Cookie(name, value));
+            }
+        }
+
+        return cookies.toArray(new Cookie[0]);
+    }
+
+    /**
      * Returns the name of the cookie.
      *
      * @return The name of the cookie.

--- a/src/main/java/de/igslandstuhl/database/server/webserver/requests/HttpHeader.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/requests/HttpHeader.java
@@ -1,8 +1,5 @@
 package de.igslandstuhl.database.server.webserver.requests;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import de.igslandstuhl.database.server.webserver.Cookie;
 
 public class HttpHeader {
@@ -41,15 +38,7 @@ public class HttpHeader {
             if (line.startsWith("Content-Length:")) {
                 contentLength = Integer.parseInt(line.split(":")[1].trim());
             } else if (line.startsWith("Cookie:")) {
-                String[] cookieData = line.substring(7).split(";");
-                List<Cookie> cookieList = new ArrayList<>();
-                for (String cookie : cookieData) {
-                    String[] keyValue = cookie.trim().split("=");
-                    if (keyValue.length == 2) {
-                        cookieList.add(new Cookie(keyValue[0].trim(), keyValue[1].trim()));
-                    }
-                }
-                cookies = cookieList.toArray(new Cookie[0]);
+                cookies = Cookie.parse(line.substring(7));
             } else if (line.startsWith("User-Agent:")) {
                 userAgent = line.split(":")[1].trim();
             } else if (line.startsWith("Accept-Language:")) {

--- a/src/test/java/de/igslandstuhl/database/server/webserver/CookieTest.java
+++ b/src/test/java/de/igslandstuhl/database/server/webserver/CookieTest.java
@@ -1,5 +1,6 @@
 package de.igslandstuhl.database.server.webserver;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -29,5 +30,60 @@ public class CookieTest {
     @Test
     void testEquals() {
         assertEquals(cookie, new Cookie("test-key", "test-value"));
+    }
+
+    @Test
+    void testParseSingleCookie() {
+        assertArrayEquals(
+            new Cookie[] {new Cookie("test-key", "test-value")},
+            Cookie.parse("test-key=test-value")
+        );
+    }
+
+    @Test
+    void testParseMultipleCookies() {
+        assertArrayEquals(
+            new Cookie[] {
+                new Cookie("first", "one"),
+                new Cookie("second", "two")
+            },
+            Cookie.parse("first=one; second=two")
+        );
+    }
+
+    @Test
+    void testParseValueContainingEqualsSign() {
+        assertArrayEquals(
+            new Cookie[] {new Cookie("token", "part1=part2=part3")},
+            Cookie.parse("token=part1=part2=part3")
+        );
+    }
+
+    @Test
+    void testParseEmptyValue() {
+        assertArrayEquals(
+            new Cookie[] {new Cookie("empty", "")},
+            Cookie.parse("empty=")
+        );
+    }
+
+    @Test
+    void testParseIgnoresInvalidPairs() {
+        assertArrayEquals(
+            new Cookie[] {
+                new Cookie("valid", "value"),
+                new Cookie("other", "cookie")
+            },
+            Cookie.parse(
+                "invalid; =missing-name; valid=value; other=cookie"
+            )
+        );
+    }
+
+    @Test
+    void testParseEmptyHeader() {
+        assertArrayEquals(new Cookie[0], Cookie.parse(null));
+        assertArrayEquals(new Cookie[0], Cookie.parse(""));
+        assertArrayEquals(new Cookie[0], Cookie.parse("   "));
     }
 }


### PR DESCRIPTION
## Summary

- move request cookie parsing into the `Cookie` class
- let `HttpHeader` delegate parsing to `Cookie.parse`
- preserve equals signs inside cookie values
- support empty cookie values
- ignore malformed cookie pairs and pairs without a name
- add direct tests for cookie parsing behavior

## Verification

The following tests pass:

- `CookieTest`
- `HttpHeaderTest`
- `PostRequestTest`
- `SessionManagerTest`

`GetRequestTest.testToResourceLocation` currently fails with an unrelated resource-path assertion. The same test also fails on an unchanged `origin/main` worktree, so it is not caused by this change.

Fixes #88
