### PR TITLE
Use AccessManager in HttpHandler

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/webserver/handlers/HttpHandler.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/handlers/HttpHandler.java
@@ -7,6 +7,7 @@ import de.igslandstuhl.database.Registry;
 import de.igslandstuhl.database.server.Server;
 import de.igslandstuhl.database.server.webserver.Status;
 import de.igslandstuhl.database.server.webserver.access.AccessLevel;
+import de.igslandstuhl.database.server.webserver.access.AccessManager;
 import de.igslandstuhl.database.server.webserver.requests.APIPostRequest;
 import de.igslandstuhl.database.server.webserver.requests.GetRequest;
 import de.igslandstuhl.database.server.webserver.requests.HttpRequest;
@@ -32,7 +33,8 @@ public class HttpHandler<Rq extends HttpRequest> {
         if (contentLength <= 0 && !(request instanceof GetRequest)) {
             return HttpResponse.error(request, Status.BAD_REQUEST);
         }
-        if (!accessLevel.hasAccess(sessionManager.getSessionUser(request))) {
+        if (!AccessManager.getInstance().hasAccess(
+                sessionManager.getSessionUser(request), path, request)) {
             return HttpResponse.error(request, Status.UNAUTHORIZED);
         } else if (!path.equals(request.getPath().split("\\?")[0])) {
             LOGGER.error("Wrong path for HTTP handler: path {} does not match handler path {}", request.getPath(), path);


### PR DESCRIPTION
## Summary

- delegate `HttpHandler` access checks to `AccessManager`
- preserve the existing handler access level and path registration
- ensure `AccessManagerEvent` hooks can affect handler access decisions

## Verification

- `./gradlew test --tests '*AccessManagerTest' --rerun-tasks --no-configuration-cache`
- `./gradlew clean build --no-configuration-cache`

Fixes #233
