### PR TITLE
Fix: use email as unique identifier for teachers instead of (first_name, last_name)fix: use email as unique identifier for teachers instead of (first_na…

### DIFF
--- a/src/main/resources/sql/pushes/add_teacher.sql
+++ b/src/main/resources/sql/pushes/add_teacher.sql
@@ -1,7 +1,6 @@
 INSERT INTO teachers (first_name, last_name, email, password)
 VALUES (?, ?, ?, ?)
-ON CONFLICT(first_name, last_name) DO UPDATE SET
-    email = excluded.email,
-    password = excluded.password
 ON CONFLICT(email) DO UPDATE SET
+    first_name = excluded.first_name,
+    last_name = excluded.last_name,
     password = excluded.password;

--- a/src/main/resources/sql/tables/teachers.sql
+++ b/src/main/resources/sql/tables/teachers.sql
@@ -3,6 +3,5 @@ CREATE TABLE IF NOT EXISTS teachers (
     first_name TEXT NOT NULL,
     last_name TEXT NOT NULL,
     email TEXT UNIQUE NOT NULL,
-    password TEXT NOT NULL,
-    UNIQUE(first_name, last_name)
+    password TEXT NOT NULL
 );


### PR DESCRIPTION
## Problem
The `teachers` table has a `UNIQUE(first_name, last_name)` constraint, and
`add_teacher.sql` upserts on `ON CONFLICT(first_name, last_name)`. This doesn't
reflect reality — two different teachers can share the same first and last name.
When that happens, adding the second teacher would overwrite the email/password
of the first teacher's record.

## Fix
- Removed `UNIQUE(first_name, last_name)` from `teachers.sql`.
- `add_teacher.sql` now upserts only on `ON CONFLICT(email)`, since `email` is
  already `UNIQUE NOT NULL` and is the actual identifying field.
- On conflict, `first_name`/`last_name` are now also updated (previously they
  would only update if the now-removed name-based conflict fired), so
  re-importing a teacher with a corrected name but the same email still works.

## Checked
No code in the Java layer looks teachers up by `(first_name, last_name)` —
only by `id` (`get_teacher_by_id.sql`) and `email` (`get_teacher_by_email.sql`),
so this change is safe.

Fixes #200