### PR TITLE
Configure Dependabot auto updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Java/Gradle dependencies
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Adds `.github/dependabot.yml` to configure Dependabot for two ecosystems:

- **gradle**: keeps Java/Gradle dependencies up to date
- **github-actions**: keeps the actions used in `.github/workflows/*.yml` up to date

Both run on a daily schedule with a limit of 10 open pull requests each.

Fixes #228