### PR TITLE
Show current task (Etappe) in teacher subject table

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
@@ -298,6 +299,11 @@ public class PostRequestHandler {
                         .addProperty("help", subjectRequests.stream().anyMatch(r -> r == SubjectRequest.HELP))
                         .addProperty("test", subjectRequests.stream().anyMatch(r -> r == SubjectRequest.EXAM))
                         .addProperty("partner", subjectRequests.stream().anyMatch(r -> r == SubjectRequest.PARTNER));
+                        String currentTask = student.getSelectedTasks().stream()
+                            .filter(task -> task.getSubject() != null && task.getSubject().equals(rq.getSubject()))
+                            .map(Task::getName)
+                            .collect(Collectors.joining(", "));
+                        builder.addProperty("currentTask", currentTask);
                     }
                 }),
                 ContentType.JSON, rq

--- a/src/main/resources/js/site/student-database.js
+++ b/src/main/resources/js/site/student-database.js
@@ -228,6 +228,7 @@ async function populateSubjectStudentList(subjectSelectId, classSelectId, studen
       const row = document.createElement('tr');
       row.innerHTML = `
           <td class="student-name">${student.name}</td>
+          <td class="student-current-task">${student.currentTask || "–"}</td>
           <td class="student-help">${student.help ? "Ja" : "Nein"}</td>
           <td class="student-experiment">${student.experiment ? "Ja" : "Nein"}</td>
           <td class="student-partner">${student.partner ? "Ja" : "Nein"}</td>

--- a/src/main/resources/templates/html/subject_info.html
+++ b/src/main/resources/templates/html/subject_info.html
@@ -12,6 +12,7 @@
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Aktuelle Etappe</th>
                     <th>Braucht Unterstützung</th>
                     <th>Braucht Betreuung für Experiment</th>
                     <th>Sucht Partner</th>


### PR DESCRIPTION
## Problem
The teacher subject overview (`subjectStudentTable`) only showed request
flags (Braucht Unterstützung / Braucht Betreuung / Sucht Partner / Bereit
für Gelingensnachweis) without any context on what the student is
currently working on.

## Fix
Adds a new "Aktuelle Etappe" column right after the student name, showing
the name(s) of the task(s) the student currently has selected
(`selectedTasks`) for the given subject — same concept as "Aktuelle
Etappe" already shown on the student's own dashboard.

- Backend: `/student-list` now includes a `currentTask` field when a
  `subjectId` is passed
- Frontend: new table column + row rendering in
  `populateSubjectStudentList`

Fixes #158