### PR TITLE
Fix: User.getUser("ANONYMOUS") returns User.ANONYMOUS instead of null

### DIFF
--- a/src/main/java/de/igslandstuhl/database/api/User.java
+++ b/src/main/java/de/igslandstuhl/database/api/User.java
@@ -101,7 +101,7 @@ public abstract class User implements APIObject {
      * @return the User object if found, or null if not found
      */
     public static User getUser(String username) {
-        if (username == null || username.isEmpty()) {
+        if (username == null || username.isEmpty() || username.equals("ANONYMOUS")) {
             return ANONYMOUS;
         }
         username = username.replace("%40", "@");


### PR DESCRIPTION
## Problem
`ANONYMOUS` is the internal username representing a not-logged-in user,
but `User.getUser()` only special-cased `null`/empty usernames. Calling
`User.getUser("ANONYMOUS")` fell through to the `Student`/`Teacher`/`Admin`
lookups, found nothing, and returned `null` instead of `User.ANONYMOUS`.

## Fix
Added `username.equals("ANONYMOUS")` to the existing null/empty check in
`getUser()`, so it now returns `User.ANONYMOUS` directly, consistent with
how the constant is documented and used elsewhere.

## Observations while reviewing
- `SessionManager.getSessionUser()` already has a `null`-fallback to
  `User.ANONYMOUS`, specifically to work around this exact bug. That
  workaround becomes redundant after this fix but is harmless to leave
  in place.
- Two admin console commands (`regenerate-user-password`,
  `change-user-password` in `Command.java`) currently return "User not
  found" for the literal username `ANONYMOUS`. After this fix they will
  instead reach `User.ANONYMOUS.setPassword()`, which throws
  `UnsupportedOperationException("Anonymous user does not have
  password")` by design. This is an existing edge case in an admin-only
  console command, not a regression introduced by this change, but
  worth being aware of.

Fixes #240