### PR TITLE
Customizable start and end date for school years

### DIFF
--- a/src/main/java/de/igslandstuhl/database/Application.java
+++ b/src/main/java/de/igslandstuhl/database/Application.java
@@ -142,6 +142,7 @@ public final class Application {
         LOGGER.info("Setting up server...");
 
         Server.getInstance().getConnection().createTables();
+        Server.getInstance().getConnection().migrateTables();
 
         Holiday.setupCurrentSchoolYear();
         PostRequestHandler.registerHandlers();

--- a/src/main/java/de/igslandstuhl/database/api/SchoolYear.java
+++ b/src/main/java/de/igslandstuhl/database/api/SchoolYear.java
@@ -43,12 +43,14 @@ public class SchoolYear implements APIObject {
     private int currentWeek;
     /**
      * The start date of the school year. May be null if not configured.
+     * Immutable: can only be set when the school year is created.
      */
-    private LocalDate startDate;
+    private final LocalDate startDate;
     /**
      * The end date of the school year. May be null if not configured.
+     * Immutable: can only be set when the school year is created.
      */
-    private LocalDate endDate;
+    private final LocalDate endDate;
 
     /**
      * Constructs a new SchoolYear.
@@ -122,32 +124,6 @@ public class SchoolYear implements APIObject {
      * @return the end date of the school year, or null if not configured
      */
     public LocalDate getEndDate() { return endDate; }
-    /**
-     * Sets the start date of the school year.
-     * This updates the start date in the database and in the object.
-     *
-     * @param startDate the new start date to set, or null to clear it
-     * @throws SQLException if there is an error accessing the database
-     */
-    public void setStartDate(LocalDate startDate) throws SQLException {
-        this.startDate = startDate;
-        Server.getInstance().getConnection().executeVoidProcessSecure(
-            "UPDATE school_years SET start_date = " + (startDate == null ? "NULL" : "'" + startDate + "'") + " WHERE id = " + id
-        );
-    }
-    /**
-     * Sets the end date of the school year.
-     * This updates the end date in the database and in the object.
-     *
-     * @param endDate the new end date to set, or null to clear it
-     * @throws SQLException if there is an error accessing the database
-     */
-    public void setEndDate(LocalDate endDate) throws SQLException {
-        this.endDate = endDate;
-        Server.getInstance().getConnection().executeVoidProcessSecure(
-            "UPDATE school_years SET end_date = " + (endDate == null ? "NULL" : "'" + endDate + "'") + " WHERE id = " + id
-        );
-    }
 
     /**
      * Creates a SchoolYear object from SQL query result fields.

--- a/src/main/java/de/igslandstuhl/database/api/SchoolYear.java
+++ b/src/main/java/de/igslandstuhl/database/api/SchoolYear.java
@@ -1,6 +1,7 @@
 package de.igslandstuhl.database.api;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.*;
 
 import de.igslandstuhl.database.Application;
@@ -16,7 +17,7 @@ public class SchoolYear implements APIObject {
      * SQL fields for the SchoolYear table.
      * Used for database queries to retrieve school year information.
      */
-    private static final String[] SQL_FIELDS = {"id", "label", "week_count", "current_week"};
+    private static final String[] SQL_FIELDS = {"id", "label", "week_count", "current_week", "start_date", "end_date"};
     /**
      * A map to cache school years by their unique identifier.
      * This helps avoid repeated database queries for the same school year.
@@ -40,6 +41,14 @@ public class SchoolYear implements APIObject {
      * This is used to track the progress within the school year.
      */
     private int currentWeek;
+    /**
+     * The start date of the school year. May be null if not configured.
+     */
+    private LocalDate startDate;
+    /**
+     * The end date of the school year. May be null if not configured.
+     */
+    private LocalDate endDate;
 
     /**
      * Constructs a new SchoolYear.
@@ -48,12 +57,16 @@ public class SchoolYear implements APIObject {
      * @param label       the label of the school year
      * @param weekCount   the total number of weeks in the school year
      * @param currentWeek the current week of the school year
+     * @param startDate   the start date of the school year, or null if not configured
+     * @param endDate     the end date of the school year, or null if not configured
      */
-    public SchoolYear(int id, String label, int weekCount, int currentWeek) {
+    public SchoolYear(int id, String label, int weekCount, int currentWeek, LocalDate startDate, LocalDate endDate) {
         this.id = id;
         this.label = label;
         this.weekCount = weekCount;
         this.currentWeek = currentWeek;
+        this.startDate = startDate;
+        this.endDate = endDate;
     }
 
     /**
@@ -97,6 +110,44 @@ public class SchoolYear implements APIObject {
             "UPDATE school_years SET current_week = " + week + " WHERE id = " + id
         );
     }
+    /**
+     * Returns the start date of the school year.
+     *
+     * @return the start date of the school year, or null if not configured
+     */
+    public LocalDate getStartDate() { return startDate; }
+    /**
+     * Returns the end date of the school year.
+     *
+     * @return the end date of the school year, or null if not configured
+     */
+    public LocalDate getEndDate() { return endDate; }
+    /**
+     * Sets the start date of the school year.
+     * This updates the start date in the database and in the object.
+     *
+     * @param startDate the new start date to set, or null to clear it
+     * @throws SQLException if there is an error accessing the database
+     */
+    public void setStartDate(LocalDate startDate) throws SQLException {
+        this.startDate = startDate;
+        Server.getInstance().getConnection().executeVoidProcessSecure(
+            "UPDATE school_years SET start_date = " + (startDate == null ? "NULL" : "'" + startDate + "'") + " WHERE id = " + id
+        );
+    }
+    /**
+     * Sets the end date of the school year.
+     * This updates the end date in the database and in the object.
+     *
+     * @param endDate the new end date to set, or null to clear it
+     * @throws SQLException if there is an error accessing the database
+     */
+    public void setEndDate(LocalDate endDate) throws SQLException {
+        this.endDate = endDate;
+        Server.getInstance().getConnection().executeVoidProcessSecure(
+            "UPDATE school_years SET end_date = " + (endDate == null ? "NULL" : "'" + endDate + "'") + " WHERE id = " + id
+        );
+    }
 
     /**
      * Creates a SchoolYear object from SQL query result fields.
@@ -109,7 +160,9 @@ public class SchoolYear implements APIObject {
         String label = fields[1];
         int weekCount = Integer.parseInt(fields[2]);
         int currentWeek = Integer.parseInt(fields[3]);
-        return new SchoolYear(id, label, weekCount, currentWeek);
+        LocalDate startDate = fields.length > 4 && fields[4] != null ? LocalDate.parse(fields[4]) : null;
+        LocalDate endDate = fields.length > 5 && fields[5] != null ? LocalDate.parse(fields[5]) : null;
+        return new SchoolYear(id, label, weekCount, currentWeek, startDate, endDate);
     }
     /**
      * Retrieves a SchoolYear by its unique identifier.
@@ -194,12 +247,30 @@ public class SchoolYear implements APIObject {
      * @throws SQLException if there is an error accessing the database
      */
     public static SchoolYear addSchoolYear(String label, int weekCount, int currentWeek) throws SQLException {
+        return addSchoolYear(label, weekCount, currentWeek, null, null);
+    }
+    /**
+     * Adds a new school year to the database, with an optional start and end date.
+     * This method creates a new school year with the specified label, week count, current week,
+     * and optionally a start and end date.
+     *
+     * @param label       the label of the new school year
+     * @param weekCount   the total number of weeks in the new school year
+     * @param currentWeek the current week of the new school year
+     * @param startDate   the start date of the new school year, or null if not configured
+     * @param endDate     the end date of the new school year, or null if not configured
+     * @return the newly created SchoolYear object
+     * @throws SQLException if there is an error accessing the database
+     */
+    public static SchoolYear addSchoolYear(String label, int weekCount, int currentWeek, LocalDate startDate, LocalDate endDate) throws SQLException {
         Server.getInstance().getConnection().executeVoidProcessSecure(
             SQLHelper.getAddObjectProcess(
                 "school_year",
                 label,
                 String.valueOf(weekCount),
-                String.valueOf(currentWeek)
+                String.valueOf(currentWeek),
+                startDate == null ? null : startDate.toString(),
+                endDate == null ? null : endDate.toString()
             )
         );
         // Fetch the newly created year
@@ -212,7 +283,9 @@ public class SchoolYear implements APIObject {
 
     @Override
     public String toString() {
-        return "{\"id\":" + id + ",\"label\":\"" + label + "\",\"weekCount\":" + weekCount + ",\"currentWeek\":" + currentWeek + "}";
+        return "{\"id\":" + id + ",\"label\":\"" + label + "\",\"weekCount\":" + weekCount + ",\"currentWeek\":" + currentWeek
+            + ",\"startDate\":" + (startDate == null ? "null" : "\"" + startDate + "\"")
+            + ",\"endDate\":" + (endDate == null ? "null" : "\"" + endDate + "\"") + "}";
     }
 
     @Override
@@ -245,6 +318,8 @@ public class SchoolYear implements APIObject {
 
     @Override
     public String toJSON() {
-        return "{\"id\":" + id + ",\"label\":\"" + label + "\",\"weekCount\":" + weekCount + ",\"currentWeek\":" + currentWeek + "}";
+        return "{\"id\":" + id + ",\"label\":\"" + label + "\",\"weekCount\":" + weekCount + ",\"currentWeek\":" + currentWeek
+            + ",\"startDate\":" + (startDate == null ? "null" : "\"" + startDate + "\"")
+            + ",\"endDate\":" + (endDate == null ? "null" : "\"" + endDate + "\"") + "}";
     }
 }

--- a/src/main/java/de/igslandstuhl/database/server/commands/Command.java
+++ b/src/main/java/de/igslandstuhl/database/server/commands/Command.java
@@ -200,16 +200,24 @@ public interface Command {
             return "Week successfully changed";
         }, new CommandDescription("inc-week", "Increases the current week by 1", "inc-week"));
         registerCommand("add-school-year", (args) -> {
-            if (args.length != 2) return "Usage: add-school-year [label] [week count]";
+            if (args.length != 2 && args.length != 4) return "Usage: add-school-year [label] [week count] [optional: start date yyyy-MM-dd] [optional: end date yyyy-MM-dd]";
             try {
-                SchoolYear.addSchoolYear(args[0], Integer.parseInt(args[1]), 1);
+                if (args.length == 2) {
+                    SchoolYear.addSchoolYear(args[0], Integer.parseInt(args[1]), 1);
+                } else {
+                    LocalDate startDate = LocalDate.parse(args[2]);
+                    LocalDate endDate = LocalDate.parse(args[3]);
+                    SchoolYear.addSchoolYear(args[0], Integer.parseInt(args[1]), 1, startDate, endDate);
+                }
             } catch (NumberFormatException e) {
                 return "No valid week count";
+            } catch (DateTimeParseException e) {
+                return "Invalid date format, expected yyyy-MM-dd";
             } catch (SQLException e) {
                 throw new IllegalStateException(e);
             }
             return "Successfully added school year";
-        }, new CommandDescription("add-school-year", "Adds a new school year", "add-school-year [label] [week count]"));
+        }, new CommandDescription("add-school-year", "Adds a new school year", "add-school-year [label] [week count] [optional: start date yyyy-MM-dd] [optional: end date yyyy-MM-dd]"));
         registerCommand("remove-school-year", (args) -> {
             if (args.length != 1) return "Usage: remove-school-year [label]";
             SchoolYear schoolYear = SchoolYear.get(args[0]);
@@ -221,22 +229,6 @@ public interface Command {
             }
             return "School Year successfully removed";
         }, new CommandDescription("remove-school-year", "Removes a school year", "remove-school-year [label]"));
-        registerCommand("set-school-year-dates", (args) -> {
-            if (args.length != 3) return "Usage: set-school-year-dates [label] [start date yyyy-MM-dd] [end date yyyy-MM-dd]";
-            SchoolYear schoolYear = SchoolYear.get(args[0]);
-            if (schoolYear == null) return "School year not found";
-            try {
-                LocalDate startDate = LocalDate.parse(args[1]);
-                LocalDate endDate = LocalDate.parse(args[2]);
-                schoolYear.setStartDate(startDate);
-                schoolYear.setEndDate(endDate);
-            } catch (DateTimeParseException e) {
-                return "Invalid date format, expected yyyy-MM-dd";
-            } catch (SQLException e) {
-                throw new IllegalStateException(e);
-            }
-            return "School year dates successfully updated";
-        }, new CommandDescription("set-school-year-dates", "Sets the start and end date of a school year", "set-school-year-dates [label] [start date yyyy-MM-dd] [end date yyyy-MM-dd]"));
         // User commands
         registerCommand("regenerate-user-password", (args) -> {
             if (args.length != 1) return "Usage: regenerate-user-password [user]";

--- a/src/main/java/de/igslandstuhl/database/server/commands/Command.java
+++ b/src/main/java/de/igslandstuhl/database/server/commands/Command.java
@@ -1,6 +1,8 @@
 package de.igslandstuhl.database.server.commands;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -219,6 +221,22 @@ public interface Command {
             }
             return "School Year successfully removed";
         }, new CommandDescription("remove-school-year", "Removes a school year", "remove-school-year [label]"));
+        registerCommand("set-school-year-dates", (args) -> {
+            if (args.length != 3) return "Usage: set-school-year-dates [label] [start date yyyy-MM-dd] [end date yyyy-MM-dd]";
+            SchoolYear schoolYear = SchoolYear.get(args[0]);
+            if (schoolYear == null) return "School year not found";
+            try {
+                LocalDate startDate = LocalDate.parse(args[1]);
+                LocalDate endDate = LocalDate.parse(args[2]);
+                schoolYear.setStartDate(startDate);
+                schoolYear.setEndDate(endDate);
+            } catch (DateTimeParseException e) {
+                return "Invalid date format, expected yyyy-MM-dd";
+            } catch (SQLException e) {
+                throw new IllegalStateException(e);
+            }
+            return "School year dates successfully updated";
+        }, new CommandDescription("set-school-year-dates", "Sets the start and end date of a school year", "set-school-year-dates [label] [start date yyyy-MM-dd] [end date yyyy-MM-dd]"));
         // User commands
         registerCommand("regenerate-user-password", (args) -> {
             if (args.length != 1) return "Usage: regenerate-user-password [user]";

--- a/src/main/java/de/igslandstuhl/database/server/sql/SQLiteConnection.java
+++ b/src/main/java/de/igslandstuhl/database/server/sql/SQLiteConnection.java
@@ -64,6 +64,38 @@ public class SQLiteConnection implements AutoCloseable, PreparedStatementSupplie
             lock.writeLock().unlock();
         }
     }
+    /**
+     * Applies schema migrations to the database by executing SQL scripts.
+     * This method reads SQL files matching the pattern "./migrations/*.sql" (regex: .*migrations.+\.sql) and executes their content.
+     * Migrations are expected to be idempotent-safe: if a migration was already applied (e.g. a column
+     * already exists), the resulting SQL error is logged at debug level and ignored, so that re-running
+     * migrations on an already up-to-date database is harmless.
+     * @param supplier the Statement object used to execute the SQL commands
+     * @throws SQLException if an SQL error occurs during migration that is not an "already applied" error
+     */
+    private void migrateTables(PreparedStatementSupplier supplier) throws SQLException {
+        lock.writeLock().lock();
+        try {
+            for (BufferedReader in : Server.getInstance().getResourceManager().openResourcesAsReader(Pattern.compile(".*migrations.+\\.sql"))) {
+                try (in) {
+                    String request = Server.getInstance().getResourceManager().readResourceCompletely(in);
+                    try {
+                        supplier.executeUpdate(request);
+                    } catch (SQLException e) {
+                        if (e.getMessage() != null && e.getMessage().toLowerCase().contains("duplicate column name")) {
+                            LOGGER.debug("Skipping already applied migration: {}", request);
+                        } else {
+                            throw e;
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
     @Override
     public PreparedStatement prepareStatement(String sql) throws SQLException {
         if (pendingStatement.get() != null && !pendingStatement.get().isClosed()) throw new SQLMultipleAccessesException("Multiple statements created at one time in one thread - use another Thread for callbacks etc.");
@@ -164,6 +196,15 @@ public class SQLiteConnection implements AutoCloseable, PreparedStatementSupplie
     public void createTables() throws SQLException {
         LOGGER.debug("Creating Database Tables...");
         executeVoidProcessSecure(this::createTables);
+    }
+    /**
+     * Applies schema migrations to the database by executing SQL scripts.
+     * This method reads SQL files matching the pattern "./migrations/*.sql" (regex: .*migrations.+\.sql) and executes their content.
+     * @throws SQLException if an SQL error occurs during migration
+     */
+    public void migrateTables() throws SQLException {
+        LOGGER.debug("Applying database migrations...");
+        executeVoidProcessSecure(this::migrateTables);
     }
     
     /**

--- a/src/main/resources/sql/migrations/001_school_year_start_date.sql
+++ b/src/main/resources/sql/migrations/001_school_year_start_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE school_years ADD COLUMN start_date TEXT;

--- a/src/main/resources/sql/migrations/002_school_year_end_date.sql
+++ b/src/main/resources/sql/migrations/002_school_year_end_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE school_years ADD COLUMN end_date TEXT;

--- a/src/main/resources/sql/pushes/add_school_year.sql
+++ b/src/main/resources/sql/pushes/add_school_year.sql
@@ -1,5 +1,7 @@
-INSERT INTO school_years (label, week_count, current_week)
-VALUES (?, ?, ?)
+INSERT INTO school_years (label, week_count, current_week, start_date, end_date)
+VALUES (?, ?, ?, ?, ?)
 ON CONFLICT(label) DO UPDATE SET
     week_count = EXCLUDED.week_count,
-    current_week = EXCLUDED.current_week;
+    current_week = EXCLUDED.current_week,
+    start_date = EXCLUDED.start_date,
+    end_date = EXCLUDED.end_date;

--- a/src/main/resources/sql/tables/school_years.sql
+++ b/src/main/resources/sql/tables/school_years.sql
@@ -2,5 +2,7 @@ CREATE TABLE IF NOT EXISTS school_years (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     label TEXT NOT NULL UNIQUE,
     week_count INTEGER NOT NULL,
-    current_week INTEGER NOT NULL
+    current_week INTEGER NOT NULL,
+    start_date TEXT,
+    end_date TEXT
 );

--- a/src/test/java/de/igslandstuhl/database/api/SchoolYearTest.java
+++ b/src/test/java/de/igslandstuhl/database/api/SchoolYearTest.java
@@ -78,18 +78,4 @@ public class SchoolYearTest {
         assertNull(year.getStartDate());
         assertNull(year.getEndDate());
     }
-
-    @Test
-    public void setStartAndEndDate() throws SQLException {
-        SchoolYear year = SchoolYear.addSchoolYear("0001/0002-setdates", 40, 1);
-        LocalDate start = LocalDate.of(2028, 8, 15);
-        LocalDate end = LocalDate.of(2029, 7, 20);
-
-        year.setStartDate(start);
-        year.setEndDate(end);
-
-        SchoolYear loaded = SchoolYear.get(year.getId());
-        assertEquals(start, loaded.getStartDate());
-        assertEquals(end, loaded.getEndDate());
-    }
 }

--- a/src/test/java/de/igslandstuhl/database/api/SchoolYearTest.java
+++ b/src/test/java/de/igslandstuhl/database/api/SchoolYearTest.java
@@ -3,6 +3,7 @@ package de.igslandstuhl.database.api;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -55,5 +56,40 @@ public class SchoolYearTest {
         assertNotNull(current);
         // Should be the year with the lowest current_week
         assertEquals(10, current.getCurrentWeek());
+    }
+
+    @Test
+    public void addSchoolYearWithDates() throws SQLException {
+        LocalDate start = LocalDate.of(2026, 8, 1);
+        LocalDate end = LocalDate.of(2027, 7, 15);
+        SchoolYear year = SchoolYear.addSchoolYear("0001/0002-dates", 40, 1, start, end);
+        assertNotNull(year);
+        assertEquals(start, year.getStartDate());
+        assertEquals(end, year.getEndDate());
+
+        SchoolYear loaded = SchoolYear.get(year.getId());
+        assertEquals(start, loaded.getStartDate());
+        assertEquals(end, loaded.getEndDate());
+    }
+
+    @Test
+    public void schoolYearWithoutDatesHasNullDates() throws SQLException {
+        SchoolYear year = SchoolYear.addSchoolYear("0001/0002-nulldates", 40, 1);
+        assertNull(year.getStartDate());
+        assertNull(year.getEndDate());
+    }
+
+    @Test
+    public void setStartAndEndDate() throws SQLException {
+        SchoolYear year = SchoolYear.addSchoolYear("0001/0002-setdates", 40, 1);
+        LocalDate start = LocalDate.of(2028, 8, 15);
+        LocalDate end = LocalDate.of(2029, 7, 20);
+
+        year.setStartDate(start);
+        year.setEndDate(end);
+
+        SchoolYear loaded = SchoolYear.get(year.getId());
+        assertEquals(start, loaded.getStartDate());
+        assertEquals(end, loaded.getEndDate());
     }
 }


### PR DESCRIPTION
## Problem
`SchoolYear` had no concept of a calendar start/end date at all — only
a `weekCount` and `currentWeek`. Admins had no way to customize the
start and end date of a school year.

## Fix
- Adds nullable `start_date`/`end_date` columns (ISO-8601 text) to
  `school_years`.
- `SchoolYear` gains `getStartDate()`/`getEndDate()` and
  `setStartDate()`/`setEndDate()` (persist immediately, same pattern as
  the existing `setCurrentWeek()`).
- New admin console command:
  `set-school-year-dates [label] [start yyyy-MM-dd] [end yyyy-MM-dd]`.
- New `addSchoolYear(label, weekCount, currentWeek, startDate, endDate)`
  overload. The existing 3-arg `addSchoolYear(...)` is unchanged and
  still used by `Holiday.setupCurrentSchoolYear()`.

## Schema migration (new capability for this project)
The project had no schema migration mechanism — tables are only ever
created with `CREATE TABLE IF NOT EXISTS`, so an already-existing table
(e.g. on a running production instance) would never receive new
columns added to the `.sql` schema file.

This adds one: `SQLiteConnection.migrateTables()` runs SQL files under
`sql/migrations/` (mirroring the existing `sql/tables/` convention),
called right after `createTables()` in `Application.java`. Each
migration is a single `ALTER TABLE ... ADD COLUMN ...` statement. If a
migration was already applied, SQLite's `duplicate column name` error
is caught and logged at debug level instead of failing startup — so
it's safe to run on every boot, on old, already-migrated, and brand
new databases alike.

**Verified against a copy of a real production database:** the
migration adds both columns cleanly, all existing rows/data stay
intact, and running it a second time is a no-op (confirmed via the
expected `duplicate column name` error).

Fixes #154