### PR TITLE
Fix: migrateTables() must also tolerate "no such column" and "no such table" errors

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/sql/SQLiteConnection.java
+++ b/src/main/java/de/igslandstuhl/database/server/sql/SQLiteConnection.java
@@ -68,8 +68,9 @@ public class SQLiteConnection implements AutoCloseable, PreparedStatementSupplie
      * Applies schema migrations to the database by executing SQL scripts.
      * This method reads SQL files matching the pattern "./migrations/*.sql" (regex: .*migrations.+\.sql) and executes their content.
      * Migrations are expected to be idempotent-safe: if a migration was already applied (e.g. a column
-     * already exists), the resulting SQL error is logged at debug level and ignored, so that re-running
-     * migrations on an already up-to-date database is harmless.
+     * or table already exists/was already renamed/dropped), the resulting SQL error ("duplicate column
+     * name", "no such column", or "no such table") is logged at debug level and ignored, so that
+     * re-running migrations on an already up-to-date database is harmless.
      * @param supplier the Statement object used to execute the SQL commands
      * @throws SQLException if an SQL error occurs during migration that is not an "already applied" error
      */
@@ -82,7 +83,11 @@ public class SQLiteConnection implements AutoCloseable, PreparedStatementSupplie
                     try {
                         supplier.executeUpdate(request);
                     } catch (SQLException e) {
-                        if (e.getMessage() != null && e.getMessage().toLowerCase().contains("duplicate column name")) {
+                        if (e.getMessage() != null && (
+                                e.getMessage().toLowerCase().contains("duplicate column name")
+                                || e.getMessage().toLowerCase().contains("no such column")
+                                || e.getMessage().toLowerCase().contains("no such table")
+                            )) {
                             LOGGER.debug("Skipping already applied migration: {}", request);
                         } else {
                             throw e;


### PR DESCRIPTION
## Problem
`migrateTables()` (introduced in #263) was only made idempotent against
`duplicate column name` errors, which was enough for the two initial
migrations (both `ADD COLUMN`). Since then, migrations using
`DROP COLUMN` (007, 008) and `RENAME TABLE` (006) were added.

On the *second* server startup after these migrations are first applied,
`migrateTables()` would hit:
- `no such column` from re-running a `DROP COLUMN` on an already-dropped column
- `no such table` from re-running `RENAME TABLE ... special_tasks ... TO individual_tasks`

Neither is currently caught, so the uncaught `SQLException` would crash
server startup on the next restart.

## Fix
Extended the idempotency check in `migrateTables()` to also tolerate
`no such column` and `no such table`, alongside the existing
`duplicate column name` check.

## Verified
Tested all 8 current migrations against a copy of a real production
database (2 runs): first run applies cleanly, all existing data
(e.g. school year rows) stays intact, second run now completes without
error for every migration type (`ADD COLUMN`, `DROP COLUMN`,
`RENAME TABLE`) instead of crashing.