### PR TITLE
Make GraduationLevel configurable

### DIFF
--- a/src/main/java/de/igslandstuhl/database/api/GraduationLevel.java
+++ b/src/main/java/de/igslandstuhl/database/api/GraduationLevel.java
@@ -1,16 +1,52 @@
 package de.igslandstuhl.database.api;
 
-public enum GraduationLevel implements APIObject {
-    LEVEL0 (0, "Neustarter"),
-    LEVEL1 (1, "Starter"),
-    LEVEL2 (2, "Durchstarter"),
-    LEVEL3 (3, "Lernprofi");
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import de.igslandstuhl.database.Registry;
+import de.igslandstuhl.database.server.resources.CoreResourceProvider;
+import de.igslandstuhl.database.server.resources.FileResourceProvider;
+import de.igslandstuhl.database.server.resources.ResourceLocation;
+import de.igslandstuhl.database.server.resources.ResourceManager;
+import de.igslandstuhl.database.utils.RegistryEnum;
+
+public class GraduationLevel extends RegistryEnum<GraduationLevel> implements APIObject {
+    private static final ResourceLocation META =
+        new ResourceLocation("meta", "api", "graduation_levels.json");
+
+    /*
+     * Local resources have priority. Plugin resources are deliberately excluded,
+     * so graduation levels can only be overridden by the local file system.
+     */
+    private static final ResourceManager RESOURCE_MANAGER =
+        new ResourceManager(
+            new FileResourceProvider(Path.of("resources")),
+            new CoreResourceProvider()
+        );
+
+    private static boolean initialized;
 
     private final int level;
     private final String germanTranslation;
 
+    private GraduationLevel(
+            Registry<String, GraduationLevel> registry,
+            String key) {
+        super(registry, key);
+        this.level = -1;
+        this.germanTranslation = key;
+    }
 
-    private GraduationLevel(int level, String germanTranslation) {
+    private GraduationLevel(
+            Registry<String, GraduationLevel> registry,
+            String key,
+            int level,
+            String germanTranslation) {
+        super(registry, key);
         this.level = level;
         this.germanTranslation = germanTranslation;
     }
@@ -29,26 +65,87 @@ public enum GraduationLevel implements APIObject {
     }
 
     public static GraduationLevel of(int level) {
-        switch (level) {
-            case 0:
-                return LEVEL0;
-            case 1:
-                return LEVEL1;
-            case 2:
-                return LEVEL2;
-            case 3:
-                return LEVEL3;
-            default:
-                throw new IllegalArgumentException("No such graduation level: " + level);
+        ensureInitialized();
+        GraduationLevel result =
+            RegistryEnum.valueOf(String.valueOf(level), GraduationLevel.class);
+
+        if (result == null) {
+            throw new IllegalArgumentException(
+                "No such graduation level: " + level
+            );
         }
+        return result;
     }
 
     public static GraduationLevel initialValue() {
-        return LEVEL1;
+        return of(1);
     }
 
     @Override
     public String toJSON() {
         return String.valueOf(level);
+    }
+
+    @Override
+    protected GraduationLevel[] values(
+            Registry<String, GraduationLevel> registry) {
+        List<GraduationLevel> levels = registry.stream()
+            .sorted(Comparator.comparingInt(GraduationLevel::getLevel))
+            .toList();
+
+        return levels.toArray(new GraduationLevel[0]);
+    }
+
+    @Override
+    protected void initValues() {
+        final Map<String, ?> config;
+
+        try {
+            config = RESOURCE_MANAGER.readJsonResourceAsMap(META);
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                "Failed to load graduation levels", e
+            );
+        }
+
+        config.forEach((key, value) -> {
+            int numericLevel = Integer.parseInt(key);
+            String translation = String.valueOf(value);
+
+            registry().register(
+                key,
+                new GraduationLevel(
+                    registry(),
+                    key,
+                    numericLevel,
+                    translation
+                )
+            );
+        });
+    }
+
+    @Override
+    protected GraduationLevel initValue(
+            Registry<String, GraduationLevel> registry,
+            String key) {
+        return new GraduationLevel(registry, key);
+    }
+
+    private static synchronized void ensureInitialized() {
+        if (initialized) {
+            return;
+        }
+
+        try {
+            RegistryEnum.init(GraduationLevel.class);
+            initialized = true;
+        } catch (InstantiationException |
+                 IllegalAccessException |
+                 IllegalArgumentException |
+                 InvocationTargetException |
+                 NoSuchMethodException |
+                 SecurityException e) {
+            throw new ExceptionInInitializerError(e);
+        }
     }
 }

--- a/src/main/java/de/igslandstuhl/database/utils/RegistryEnum.java
+++ b/src/main/java/de/igslandstuhl/database/utils/RegistryEnum.java
@@ -34,6 +34,10 @@ public abstract class RegistryEnum<T extends RegistryEnum<T>> {
         return values(registry);
     }
 
+    protected Registry<String,T> registry() {
+        return registry;
+    }
+
     protected abstract void initValues();
 
     protected abstract T initValue(Registry<String, T> registry, String key);

--- a/src/main/resources/meta/api/graduation_levels.json
+++ b/src/main/resources/meta/api/graduation_levels.json
@@ -1,0 +1,6 @@
+{
+    "0": "Neustarter",
+    "1": "Starter",
+    "2": "Durchstarter",
+    "3": "Lernprofi"
+}

--- a/src/test/java/de/igslandstuhl/database/api/GraduationLevelTest.java
+++ b/src/test/java/de/igslandstuhl/database/api/GraduationLevelTest.java
@@ -1,0 +1,76 @@
+package de.igslandstuhl.database.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.igslandstuhl.database.server.resources.CoreResourceProvider;
+import de.igslandstuhl.database.server.resources.FileResourceProvider;
+import de.igslandstuhl.database.server.resources.ResourceLocation;
+import de.igslandstuhl.database.server.resources.ResourceManager;
+
+class GraduationLevelTest {
+
+    @Test
+    void defaultLevelsMatchPreviousBehavior() {
+        assertEquals("Neustarter", GraduationLevel.of(0).getGermanTranslation());
+        assertEquals("Starter", GraduationLevel.of(1).getGermanTranslation());
+        assertEquals("Durchstarter", GraduationLevel.of(2).getGermanTranslation());
+        assertEquals("Lernprofi", GraduationLevel.of(3).getGermanTranslation());
+    }
+
+    @Test
+    void initialValueIsLevelOne() {
+        assertEquals(1, GraduationLevel.initialValue().getLevel());
+    }
+
+    @Test
+    void valuesAreOrderedByNumericLevel() {
+        GraduationLevel[] values = GraduationLevel.of(0).values();
+
+        assertEquals(4, values.length);
+        assertEquals(0, values[0].getLevel());
+        assertEquals(1, values[1].getLevel());
+        assertEquals(2, values[2].getLevel());
+        assertEquals(3, values[3].getLevel());
+    }
+
+
+    @Test
+    void localConfigurationOverridesCoreConfiguration(@TempDir Path tempDir)
+            throws Exception {
+        Path config = tempDir.resolve("meta/api/graduation_levels.json");
+        Files.createDirectories(config.getParent());
+        Files.writeString(config, """
+            {
+                "1": "Lokaler Starter"
+            }
+            """);
+
+        ResourceManager manager = new ResourceManager(
+            new FileResourceProvider(tempDir),
+            new CoreResourceProvider()
+        );
+
+        Map<String, ?> levels = manager.readJsonResourceAsMap(
+            new ResourceLocation("meta", "api", "graduation_levels.json")
+        );
+
+        assertEquals("Lokaler Starter", levels.get("1"));
+        assertEquals(1, levels.size());
+    }
+
+    @Test
+    void unknownLevelThrowsException() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> GraduationLevel.of(999)
+        );
+    }
+}

--- a/src/test/java/de/igslandstuhl/database/api/PreConditions.java
+++ b/src/test/java/de/igslandstuhl/database/api/PreConditions.java
@@ -11,7 +11,7 @@ public class PreConditions {
         server.getConnection().createTables();
     }
     public static void addSampleStudent() throws SQLException {
-        Student.registerStudentWithPassword(0, "Max", "Mustermann", "max@muster.mann", "12345", SchoolClass.get(1), GraduationLevel.LEVEL1);
+        Student.registerStudentWithPassword(0, "Max", "Mustermann", "max@muster.mann", "12345", SchoolClass.get(1), GraduationLevel.of(1));
     }
     public static void addSampleSubject() throws SQLException {
         Subject.addSubject("Mathematik");

--- a/src/test/java/de/igslandstuhl/database/api/StudentTest.java
+++ b/src/test/java/de/igslandstuhl/database/api/StudentTest.java
@@ -15,7 +15,7 @@ public class StudentTest {
     }
     @Test
     public void testPuttingStudent() throws SQLException {
-        Student added = Student.registerStudentWithPassword(0, "Max", "Mustermann", "max@muster.mann", "12345", SchoolClass.get(1), GraduationLevel.LEVEL1);
+        Student added = Student.registerStudentWithPassword(0, "Max", "Mustermann", "max@muster.mann", "12345", SchoolClass.get(1), GraduationLevel.of(1));
         Student student = Student.get(0);
         assertEquals(added, student);
     }

--- a/src/test/java/de/igslandstuhl/database/server/ServerTest.java
+++ b/src/test/java/de/igslandstuhl/database/server/ServerTest.java
@@ -44,7 +44,7 @@ public class ServerTest {
     public void testValidUser() throws SQLException {
         server.getConnection().createTables(); // Ensure tables are created before testing user validation
         SchoolClass.addClass("5a", 5);
-        Student.registerStudentWithPassword(0, "Max", "Mustermann", "max@muster.mann", "12345", SchoolClass.get(1), GraduationLevel.LEVEL1);
+        Student.registerStudentWithPassword(0, "Max", "Mustermann", "max@muster.mann", "12345", SchoolClass.get(1), GraduationLevel.of(1));
         assertFalse(server.isValidUser("anamethatnostudentwillevergetbecauseitistoolongtoputintotheloginfield", "password"));
         assertFalse(server.isValidUser("max@muster.mann", "123456")); // Test student set up by StudentTest
         assertTrue(server.isValidUser("max@muster.mann", "12345"));


### PR DESCRIPTION
Fixes #213

- convert `GraduationLevel` from a Java enum to a `RegistryEnum`
- load graduation levels from `meta/api/graduation_levels.json`
- allow local filesystem configuration to override the built-in core configuration
- exclude plugin resources from graduation-level configuration
- preserve numeric database compatibility through `of(int)`, `getLevel()`, `initialValue()`, and JSON serialization
- update existing tests to use the registry-backed API
- add regression tests for default levels, ordering, invalid levels, initial value, and local override behavior

Tests:
- `./gradlew clean test`
- `./gradlew clean build`
