### PR TITLE
Implement admin HTML editor

### DIFF
--- a/src/main/java/de/igslandstuhl/database/client/HTMLFileTemplate.java
+++ b/src/main/java/de/igslandstuhl/database/client/HTMLFileTemplate.java
@@ -21,16 +21,34 @@ public class HTMLFileTemplate implements HTMLTemplate {
 
         return resolved.getFileName().toString();
     }
-    private final String templateString;
+    private final ResourceLocation file;
+
     public HTMLFileTemplate(ResourceLocation file) throws FileNotFoundException {
-        templateString = Server.getInstance().getResourceManager().readResourceCompletely(file);
+        Server.getInstance().getResourceManager().readResourceCompletely(file);
+        this.file = file;
     }
     public HTMLFileTemplate(String file) throws FileNotFoundException {
         this(new ResourceLocation("templates", "html", sanitizeTemplateName(file)));
     }
     @Override
     public String fill(Map<String, String> args) {
+        final String templateString;
+
+        try {
+            templateString = Server.getInstance()
+                .getResourceManager()
+                .readResourceCompletely(file);
+        } catch (FileNotFoundException e) {
+            HTMLTemplate.LOGGER.error(
+                "Failed to reload html template '{}'",
+                file,
+                e
+            );
+            return "";
+        }
+
         if (templateString == null || templateString.isEmpty()) return "";
+
         Pattern p = Pattern.compile("%\\{([^}]+)\\}");
         Matcher m = p.matcher(templateString);
         StringBuffer sb = new StringBuffer();

--- a/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
@@ -113,6 +115,38 @@ public class PostRequestHandler {
         }
         return webInput;
     }
+    static Path resolveTemplatePath(String filename) {
+        if (filename == null || filename.isBlank()) {
+            throw new IllegalArgumentException(
+                "Template filename is required"
+            );
+        }
+
+        if (!filename.endsWith(".html")) {
+            throw new IllegalArgumentException(
+                "Only .html template files can be edited"
+            );
+        }
+
+        Path base = Path.of(
+            "resources",
+            "templates",
+            "html"
+        ).toAbsolutePath().normalize();
+
+        Path target = base.resolve(filename).normalize();
+
+        if (!target.startsWith(base)
+                || target.getParent() == null
+                || !target.getParent().equals(base)) {
+            throw new IllegalArgumentException(
+                "Invalid template filename"
+            );
+        }
+
+        return target;
+    }
+
     private static PostResponse handleStudentGetData(APIPostRequest request) {
         String path = request.getPath().replace("student-", "my");
         Student student = request.getCurrentStudent();
@@ -191,6 +225,24 @@ public class PostRequestHandler {
             }
         });
         HttpHandler.registerPostRequestHandler("/editor", AccessLevel.ADMIN, (rq) -> {
+            String filename = prepare(rq.getString("filename"), false);
+            String content = prepare(rq.getString("content"), false);
+
+            final Path target;
+
+            try {
+                target = resolveTemplatePath(filename);
+            } catch (IllegalArgumentException e) {
+                return PostResponse.badRequest(e.getMessage(), rq);
+            }
+
+            Files.createDirectories(target.getParent());
+            Files.writeString(
+                target,
+                content,
+                StandardCharsets.UTF_8
+            );
+
             return PostResponse.redirect("/editor", rq);
         });
 

--- a/src/test/java/de/igslandstuhl/database/client/HTMLFileTemplateTest.java
+++ b/src/test/java/de/igslandstuhl/database/client/HTMLFileTemplateTest.java
@@ -1,0 +1,73 @@
+package de.igslandstuhl.database.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.igslandstuhl.database.server.resources.ResourceLocation;
+
+class HTMLFileTemplateTest {
+
+    private final Path override =
+        Path.of("resources", "templates", "html", "login.html");
+
+    private boolean overrideExisted;
+    private byte[] originalContent;
+
+    @BeforeEach
+    void backUpExistingOverride() throws Exception {
+        overrideExisted = Files.exists(override);
+
+        if (overrideExisted) {
+            originalContent = Files.readAllBytes(override);
+        }
+    }
+
+    @AfterEach
+    void restoreExistingOverride() throws Exception {
+        if (overrideExisted) {
+            Files.createDirectories(override.getParent());
+            Files.write(override, originalContent);
+        } else {
+            Files.deleteIfExists(override);
+        }
+    }
+
+    @Test
+    void reloadsLocalOverrideWithoutRestart() throws Exception {
+        Files.createDirectories(override.getParent());
+
+        Files.writeString(
+            override,
+            "First %{value}",
+            StandardCharsets.UTF_8
+        );
+
+        HTMLFileTemplate template = new HTMLFileTemplate(
+            new ResourceLocation("templates", "html", "login.html")
+        );
+
+        assertEquals(
+            "First test\n",
+            template.fill(Map.of("value", "test"))
+        );
+
+        Files.writeString(
+            override,
+            "Second %{value}",
+            StandardCharsets.UTF_8
+        );
+
+        assertEquals(
+            "Second test\n",
+            template.fill(Map.of("value", "test"))
+        );
+    }
+}

--- a/src/test/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandlerTest.java
+++ b/src/test/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandlerTest.java
@@ -1,0 +1,65 @@
+package de.igslandstuhl.database.server.webserver.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class PostRequestHandlerTest {
+
+    @Test
+    void resolvesValidHtmlTemplatePath() {
+        Path path =
+            PostRequestHandler.resolveTemplatePath("login.html");
+
+        assertTrue(path.isAbsolute());
+        assertTrue(
+            path.endsWith(
+                Path.of(
+                    "resources",
+                    "templates",
+                    "html",
+                    "login.html"
+                )
+            )
+        );
+    }
+
+    @Test
+    void rejectsPathTraversal() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PostRequestHandler.resolveTemplatePath(
+                "../evil.html"
+            )
+        );
+    }
+
+    @Test
+    void rejectsSubdirectories() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PostRequestHandler.resolveTemplatePath(
+                "subdir/login.html"
+            )
+        );
+    }
+
+    @Test
+    void rejectsNonHtmlFiles() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> PostRequestHandler.resolveTemplatePath(
+                "login.txt"
+            )
+        );
+
+        assertEquals(
+            "Only .html template files can be edited",
+            exception.getMessage()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #177

- implement saving HTML templates from the existing admin HTML editor
- store edited templates as local resource overrides under `resources/templates/html`
- prevent path traversal and restrict editing to direct `.html` template files
- reload HTML file templates when rendering so changes take effect without a server restart
- add regression tests for live template reloads and safe template path handling

Tests:
- `./gradlew clean test`
- `./gradlew clean build`