### PR TITLE
Add task attempt counter

### DIFF
--- a/src/main/java/de/igslandstuhl/database/api/Student.java
+++ b/src/main/java/de/igslandstuhl/database/api/Student.java
@@ -79,6 +79,11 @@ public class Student extends User {
     private final Set<Task> lockedTasks = new HashSet<>();
 
     /**
+     * Number of attempts per task, indexed by task ID.
+     */
+    private final Map<Integer, Integer> taskAttempts = new HashMap<>();
+
+    /**
      * The current requests of the student, mapped by subject ID.
      */
     private final Map<Integer, Set<SubjectRequest>> currentRequests = new ConcurrentHashMap<>();
@@ -149,6 +154,12 @@ public class Student extends User {
             IndividualTask st = IndividualTask.get(Integer.parseInt(t[0]));
             if (st != null) completedTasks.add(st);
         }, "get_completed_individual_tasks_by_student", INTERESTING_SPECIAL_TASK_STAT_FIELDS, String.valueOf(id));
+
+        Server.getInstance().processRequest((t) -> {
+            int taskId = Integer.parseInt(t[0]);
+            int attempts = Integer.parseInt(t[1]);
+            taskAttempts.put(taskId, attempts);
+        }, "get_task_attempts_by_student", new String[] {"task", "attempts"}, String.valueOf(id));
 
         // Defensive cleanup: ensure no nulls remained
         selectedTasks.removeIf(Objects::isNull);
@@ -363,6 +374,28 @@ public class Student extends User {
     public Set<Task> getLockedTasks() { return new HashSet<>(lockedTasks); }
 
     /**
+     * Returns the number of attempts for a task.
+     *
+     * @param task task to look up
+     * @return attempt count, or 0 if the task has never been started
+     */
+    public int getTaskAttempts(Task task) {
+        if (task == null) {
+            throw new IllegalArgumentException("Task cannot be null");
+        }
+        return taskAttempts.getOrDefault(task.getId(), 0);
+    }
+
+    /**
+     * Returns all task attempt counters, indexed by task ID.
+     *
+     * @return copy of the attempt counters
+     */
+    public Map<Integer, Integer> getTaskAttempts() {
+        return new HashMap<>(taskAttempts);
+    }
+
+    /**
      * Returns the current requests.
      * @return current requests
      */
@@ -439,24 +472,16 @@ public class Student extends User {
     }
 
     public void beginTask(Task task) throws SQLException {
-        if (task == null) {
-            throw new IllegalArgumentException("Task cannot be null");
-        }
-        // Update in DB
-        Server.getInstance().getConnection().executeVoidProcessSecure(
-            SQLHelper.getAddObjectProcess("taskstat",
-                String.valueOf(id),
-                String.valueOf(task.getId()),
-                "1" // 1 indicates the task is in progress
-            )
-        );
-        // Update in memory
-        selectedTasks.add(task);
+        changeTaskStatus(task, Task.STATUS_IN_PROGRESS);
     }
     public void changeTaskStatus(Task task, int newStatus) throws SQLException {
         if (task == null) {
             throw new IllegalArgumentException("Task cannot be null");
         }
+        boolean startsNewAttempt =
+            newStatus == Task.STATUS_IN_PROGRESS
+            && !selectedTasks.contains(task);
+
         // Update in memory
         if (newStatus == Task.STATUS_COMPLETED) {
             selectedTasks.remove(task);
@@ -478,13 +503,23 @@ public class Student extends User {
             throw new IllegalArgumentException("Invalid task status: " + newStatus);
         }
         // Update in DB
-        Server.getInstance().getConnection().executeVoidProcessSecure(
-            SQLHelper.getAddObjectProcess("taskstat",
-                String.valueOf(id),
-                String.valueOf(task.getId()),
-                String.valueOf(newStatus)
-            )
-        );
+        if (startsNewAttempt) {
+            Server.getInstance().getConnection().executeVoidProcessSecure(
+                SQLHelper.getAddObjectProcess("taskstat_begin",
+                    String.valueOf(id),
+                    String.valueOf(task.getId())
+                )
+            );
+            taskAttempts.merge(task.getId(), 1, Integer::sum);
+        } else {
+            Server.getInstance().getConnection().executeVoidProcessSecure(
+                SQLHelper.getAddObjectProcess("taskstat",
+                    String.valueOf(id),
+                    String.valueOf(task.getId()),
+                    String.valueOf(newStatus)
+                )
+            );
+        }
     }
     public Student changeGraduationLevel(int graduationLevel) throws SQLException {
         Server.getInstance().getConnection().executeVoidProcessSecure(SQLHelper.getUpdateObjectProcess("graduation_level", String.valueOf(graduationLevel), String.valueOf(id)));
@@ -535,6 +570,12 @@ public class Student extends User {
         .append("\"selectedTasks\": ").append(selectedTasks).append(",\n")
         .append("\"completedTasks\": ").append(completedTasks).append(",\n")
         .append("\"lockedTasks\": ").append(lockedTasks).append(",\n")
+        .append("\"taskAttempts\": {")
+        .append(taskAttempts.entrySet().stream()
+            .map(entry -> "\"" + entry.getKey() + "\": " + entry.getValue())
+            .reduce((a, b) -> a + ", " + b)
+            .orElse(""))
+        .append("},\n")
         .append("\"currentRequests\": {").append(currentRequests.entrySet().stream()
             .map(entry -> "\"" + entry.getKey() + "\": " + entry.getValue().stream().map((r) -> '"' + r.getGermanTranslation() + '"').toList())
             .reduce((a, b) -> a + ", " + b).orElse("")).append("},\n")

--- a/src/main/resources/js/site/student-database.js
+++ b/src/main/resources/js/site/student-database.js
@@ -393,7 +393,12 @@ function createList(items, textBuilder, labelText, onClick) {
     return { label, list };
 }
 function createTaskList(tasks, titleText, onClick) {
-    return createList(tasks, task => `${task.number} ${decodeEntities(task.name)} (Niveau ${task.niveau}, Gesamtanteil: ${Math.round(task.ratio * 10000) / 100}%)`, titleText, onClick);
+    return createList(
+        tasks,
+        task => `${task.number} ${decodeEntities(task.name)} (Niveau ${task.niveau}, Gesamtanteil: ${Math.round(task.ratio * 10000) / 100}%, Versuche: ${task.attempts ?? 0})`,
+        titleText,
+        onClick
+    );
 }
 async function buildTeacherDashboard(classes, subjects) {
     async function onClassChange(event) {
@@ -563,6 +568,14 @@ function createSubjectPanel(subject, studentData, teacherPerms) {
         if (Array.isArray(topic.tasks) && topic.tasks.length > 0) {
             allTasks = await fetchTasks(topic.tasks, studentId);
         }
+
+        const attemptCount = task =>
+            Number(studentData.taskAttempts?.[task.id] ?? 0);
+
+        [...selectedTasks, ...completedTasks, ...lockedTasks, ...allTasks]
+            .forEach(task => {
+                task.attempts = attemptCount(task);
+            });
 
         const otherTasks = allTasks.filter(
             task =>

--- a/src/main/resources/sql/migrations/009_taskstat_attempts.sql
+++ b/src/main/resources/sql/migrations/009_taskstat_attempts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE taskstats ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;
+UPDATE taskstats SET attempts = 1 WHERE attempts = 0;

--- a/src/main/resources/sql/pushes/add_taskstat_begin.sql
+++ b/src/main/resources/sql/pushes/add_taskstat_begin.sql
@@ -1,0 +1,5 @@
+INSERT INTO taskstats (student, task, status, attempts)
+VALUES (?, ?, 1, 1)
+ON CONFLICT(student, task) DO UPDATE SET
+    status = 1,
+    attempts = taskstats.attempts + 1;

--- a/src/main/resources/sql/queries/get_task_attempts_by_student.sql
+++ b/src/main/resources/sql/queries/get_task_attempts_by_student.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM taskstats
+WHERE student=?;

--- a/src/main/resources/sql/tables/taskstats.sql
+++ b/src/main/resources/sql/tables/taskstats.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS taskstats (
     student INTEGER NOT NULL,
     task INTEGER NOT NULL,
     status INTEGER NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
     last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (student, task),
     FOREIGN KEY (student) REFERENCES students(id) ON DELETE CASCADE,

--- a/src/test/java/de/igslandstuhl/database/api/StudentTest.java
+++ b/src/test/java/de/igslandstuhl/database/api/StudentTest.java
@@ -31,4 +31,47 @@ public class StudentTest {
         student.assignTopic(topic);
         assertEquals(topic, student.getCurrentTopic(topic.getSubject()));
     }
+
+    @Test
+    public void testTaskAttemptCounter() throws SQLException {
+        PreConditions.addSampleStudent();
+        PreConditions.addSampleSchoolYear();
+        PreConditions.addSampleSubject();
+        PreConditions.addSampleTopic();
+
+        Student student = Student.get(0);
+        assertNotNull(student);
+
+        PreConditions.addSampleTask();
+
+        Task task = Task.get(1);
+        assertNotNull(task);
+
+        // Never started.
+        assertEquals(0, student.getTaskAttempts(task));
+
+        // First real start -> attempt 1.
+        student.changeTaskStatus(task, Task.STATUS_IN_PROGRESS);
+        assertEquals(1, student.getTaskAttempts(task));
+
+        // Duplicate start while already in progress must not count again.
+        student.changeTaskStatus(task, Task.STATUS_IN_PROGRESS);
+        assertEquals(1, student.getTaskAttempts(task));
+
+        // Leaving the task does not increase the counter.
+        student.changeTaskStatus(task, Task.STATUS_NOT_STARTED);
+        assertEquals(1, student.getTaskAttempts(task));
+
+        // Starting it again is a new attempt.
+        student.changeTaskStatus(task, Task.STATUS_IN_PROGRESS);
+        assertEquals(2, student.getTaskAttempts(task));
+
+        // Counter is exposed through the student JSON API.
+        assertTrue(
+            student.toJSON().contains(
+                "\"" + task.getId() + "\": 2"
+            )
+        );
+    }
+
 }


### PR DESCRIPTION
Partially addresses #161

- add an `attempts` counter to `taskstats`
- migrate existing task-stat rows to one previous attempt
- increment attempts only when a task actually enters a new in-progress attempt
- avoid double-counting duplicate start requests while a task is already in progress
- expose task attempt counts through the student JSON API
- display attempt counts for tasks in the student dashboard
- add regression coverage for first start, duplicate start, leaving a task, restarting, and JSON output

The remaining #161 requirement — displaying the counter in the Teacher Test Table — will be completed together with #159, because that table does not exist yet.

Tests:
- `./gradlew test --tests "de.igslandstuhl.database.api.StudentTest.testTaskAttemptCounter" --rerun-tasks`
- `./gradlew clean test`
- `./gradlew clean build`
- manual migration check against a pre-`attempts` `taskstats` table