### PR TITLE
Avoid logging HTTP response bodies

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/webserver/responses/PostResponse.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/responses/PostResponse.java
@@ -118,7 +118,11 @@ public class PostResponse implements HttpResponse {
         }
         out.print("\r\n");
         if (body != null) {
-            WebServer.LOGGER.debug("Response body: {}", body);
+            WebServer.LOGGER.debug(
+                    "HTTP response: status={}, contentType={}, bodyLength={}",
+                    statusCode,
+                    contentType.getName(),
+                    body.getBytes(java.nio.charset.StandardCharsets.UTF_8).length);
             out.print(body);
         }
         out.flush();


### PR DESCRIPTION
## Summary
- stop writing complete HTTP response bodies to DEBUG logs
- log only status, content type, and UTF-8 body length
- prevents JSON, tokens, HTML and large SVG payloads from being written to the journal

## Validation
- branch is based on current main
- diff contains only PostResponse.java
- ./gradlew clean build completed successfully

This fixes the log flooding observed with the Attendance display QR refresh without changing HTTP response content or behavior.