### PR TITLE
Fix partner search endpoint and matching

### DIFF
--- a/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
+++ b/src/main/java/de/igslandstuhl/database/server/webserver/handlers/PostRequestHandler.java
@@ -329,9 +329,10 @@ public class PostRequestHandler {
             Student student = rq.getCurrentStudent();
 
             List<Student> students = Student.getAll().stream()
-                                        .filter((s) -> s.getSchoolClass().getGrade() == schoolClass.getGrade())
-                                        .filter((s) -> s.getCurrentTopic(subject).equals(topic)
-                                            && s.getSelectedTasks().stream().filter((t) -> t.getTopic().equals(topic)).anyMatch((t) -> student.getSelectedTasks().contains(t))
+                                        .filter((s) -> s.getId() != student.getId())
+                                        .filter((s) -> s.getSchoolClass() != null && s.getSchoolClass().getGrade() == schoolClass.getGrade())
+                                        .filter((s) -> topic != null && topic.equals(s.getCurrentTopic(subject))
+                                            && s.getSelectedTasks().stream().filter((t) -> topic.equals(t.getTopic())).anyMatch((t) -> student.getSelectedTasks().contains(t))
                                             && s.getCurrentRequests(subject).stream().anyMatch((r) -> r == SubjectRequest.PARTNER))
                                             .toList();
             return PostResponse.ok(JSONUtils.toJSON(students, (partner, builder) -> {

--- a/src/main/resources/meta/paths/post_paths.json
+++ b/src/main/resources/meta/paths/post_paths.json
@@ -155,7 +155,7 @@
         "namespaces": [],
         "access_level": "admin"
     },
-    "/search-partners": {
+    "/search-partner": {
         "type": "POST",
         "handler_type": "PostRequestHandler",
         "namespaces": [],


### PR DESCRIPTION
## Summary

Fixes the student partner search flow.

### Changes
- aligns the registered metadata path with the actual handler: `/search-partner`
- excludes the requesting student from partner results
- makes current-topic matching null-safe
- keeps matching constrained to same grade, same current topic, overlapping selected task, and active PARTNER request

## Root cause

The POST handler was registered as `/search-partner`, while `post_paths.json` declared `/search-partners`. Access control therefore failed before the handler could run.

Additionally, the previous topic comparison could throw a NullPointerException when a student had no current topic for the subject.

## Validation

Tested on the Arcanum demo environment:
- demo starts and listens on port 8444
- Mariella's `/search-partner` request returns HTTP 200
- returns Pedro Haselmann da Silva (ID 1970) and Kaito Kleylein (ID 1982)
- requesting student is excluded
- no partner-related NPE remains in logs
- Attendance remains functional

## Deployment note

The running demo binary is based on an older compatible backend binary line. For demo validation, only the affected handler class family and path resource were patched into the known-good binary so unrelated WebServer/plugin-loader incompatibilities were not introduced.

This PR itself contains only the source-level partner-search fix against current `main`.
